### PR TITLE
stringify interactions state

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,12 +7,7 @@
 		"url": "git+https://github.com/igrlk/storybook-addon-test-codegen.git"
 	},
 	"packageManager": "pnpm@9.15.3",
-	"keywords": [
-		"storybook-addons",
-		"interactions",
-		"test",
-		"codegen"
-	],
+	"keywords": ["storybook-addons", "interactions", "test", "codegen"],
 	"main": "dist/index.cjs",
 	"module": "dist/index.js",
 	"types": "dist/index.d.ts",
@@ -34,12 +29,7 @@
 		"./manager": "./dist/manager.js",
 		"./package.json": "./package.json"
 	},
-	"files": [
-		"dist/**/*",
-		"README.md",
-		"*.js",
-		"*.d.ts"
-	],
+	"files": ["dist/**/*", "README.md", "*.js", "*.d.ts"],
 	"scripts": {
 		"build": "tsup",
 		"build:watch": "concurrently \"npm run build -- --watch\" \"npm run tailwind:watch\"",
@@ -108,15 +98,9 @@
 		"access": "public"
 	},
 	"bundler": {
-		"exportEntries": [
-			"src/index.ts"
-		],
-		"managerEntries": [
-			"src/manager.tsx"
-		],
-		"previewEntries": [
-			"src/preview.ts"
-		]
+		"exportEntries": ["src/index.ts"],
+		"managerEntries": ["src/manager.tsx"],
+		"previewEntries": ["src/preview.ts"]
 	},
 	"storybook": {
 		"displayName": "Test Codegen",
@@ -134,8 +118,6 @@
 		"icon": "https://user-images.githubusercontent.com/321738/63501763-88dbf600-c4cc-11e9-96cd-94adadc2fd72.png"
 	},
 	"lint-staged": {
-		"*": [
-			"pnpm check"
-		]
+		"*": ["pnpm check"]
 	}
 }

--- a/src/manager.tsx
+++ b/src/manager.tsx
@@ -3,10 +3,10 @@ import { addons, types } from 'storybook/internal/manager-api';
 import { AddonPanel, Badge, Spaced } from 'storybook/internal/components';
 import { InteractionRecorder } from './InteractionRecorder';
 import { ADDON_ID, PANEL_ID } from './constants';
-import { useIsRecording, useRecorderState } from './state';
+import { useInteractions, useIsRecording } from './state';
 
 function Title() {
-	const [{ interactions }] = useRecorderState();
+	const [interactions] = useInteractions();
 	const [isRecording] = useIsRecording();
 
 	return (
@@ -15,7 +15,9 @@ function Title() {
 				<span style={{ display: 'inline-block', verticalAlign: 'middle' }}>
 					Interaction Recorder
 				</span>
-				{isRecording && <Badge status="neutral">{interactions.length}</Badge>}
+				{isRecording && (
+					<Badge status="neutral">{JSON.parse(interactions).length}</Badge>
+				)}
 			</Spaced>
 		</div>
 	);

--- a/src/state.ts
+++ b/src/state.ts
@@ -30,12 +30,11 @@ export type Interaction = {
 	event: InteractionEvent;
 };
 
-export const useRecorderState = () =>
-	useAddonState<{
-		interactions: Interaction[];
-	}>(ADDON_ID, {
-		interactions: [],
-	});
+// Interactions are stored as stringified Interaction[],
+// because latest storybook has some issues with storing objects in addon state,
+// where whenever you update the array, if number of elements are same, it doesn't trigger re-render
+export const useInteractions = () =>
+	useAddonState<string>(ADDON_ID, JSON.stringify([]));
 
 export const useIsRecording = () => {
 	const [globals, setGlobals] = useGlobals();


### PR DESCRIPTION
after upgrading to latest storybook `useAddonState.setState` doesn't cause re-render if array length doesn't change