### PR TITLE
Improvements for Storybook 9 support

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -2,7 +2,10 @@ import type { StorybookConfig } from '@storybook/react-vite';
 const config: StorybookConfig = {
 	stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx)'],
 	addons: ['./local-preset.js', '@storybook/addon-docs'],
-
+	features: {
+		actions: false,
+		controls: false,
+	},
 	framework: {
 		name: '@storybook/react-vite',
 		options: {},

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,5 +1,10 @@
 import type { Preview } from '@storybook/react-vite';
-import './tailwind.css';
+import '../src/tailwind.css';
+import { configure } from 'storybook/test';
+
+configure({
+	testIdAttribute: 'my-custom-attribute',
+});
 
 const preview: Preview = {
 	parameters: {
@@ -8,9 +13,6 @@ const preview: Preview = {
 				color: /(background|color)$/i,
 				date: /Date$/,
 			},
-		},
-		testCodegen: {
-			testIdAttribute: 'data-testid',
 		},
 	},
 };

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
 		"@medv/finder": "^4.0.2",
 		"@playwright/test": "^1.51.1",
 		"@storybook/addon-docs": "9.0.0-beta.6",
-		"@storybook/csf": "^0.1.13",
 		"@storybook/icons": "^1.4.0",
 		"@storybook/react-vite": "9.0.0-beta.6",
 		"@testing-library/dom": "^10.4.0",
@@ -95,7 +94,7 @@
 		"zx": "^7.2.3"
 	},
 	"peerDependencies": {
-		"storybook": ">=9.0.0"
+		"storybook": "^9.0.0 || ^9.0.0-alpha.12 || ^0.0.0-0"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/src/codegen/generate-story-code.ts
+++ b/src/codegen/generate-story-code.ts
@@ -1,5 +1,5 @@
-import { storyNameFromExport, toId } from '@storybook/csf';
 import { formatFileContent } from 'storybook/internal/common';
+import { storyNameFromExport, toId } from 'storybook/internal/csf';
 import { type CsfFile, printCsf } from 'storybook/internal/csf-tools';
 import type { GeneratedCode } from './interactions-to-code';
 import {

--- a/src/decorators/state.ts
+++ b/src/decorators/state.ts
@@ -1,14 +1,16 @@
 import { useParameter } from 'storybook/internal/preview-api';
+import { getConfig } from 'storybook/test';
 import { PARAMETER } from '../constants';
 
 export const useAddonParameters = () => {
 	const parameters = useParameter(PARAMETER) as {
 		testIdAttribute?: string;
 	} | null;
+	const testIdAttribute = getConfig().testIdAttribute ?? 'data-testid';
 
 	if (!parameters || typeof parameters !== 'object') {
-		return { testIdAttribute: 'data-testid' };
+		return { testIdAttribute };
 	}
 
-	return { testIdAttribute: parameters.testIdAttribute ?? 'data-testid' };
+	return { testIdAttribute: parameters.testIdAttribute ?? testIdAttribute };
 };

--- a/src/stories/MultiStepForm.stories.tsx
+++ b/src/stories/MultiStepForm.stories.tsx
@@ -4,6 +4,11 @@ import { MultiStepForm } from './MultiStepForm';
 
 const meta: Meta<typeof MultiStepForm> = {
 	component: MultiStepForm,
+	parameters: {
+		testCodegen: {
+			testIdAttribute: 'data-testid',
+		},
+	},
 };
 export default meta;
 


### PR DESCRIPTION
- Removed deprecated `@storybook/csf` dependency in favor of storybook/internal/csf.
- Updated `storybook` peer dependency to proper prerelease range.
- Disabled actions and controls features in Storybook configuration.
- Adjusted import paths for `tailwind.css` and updated test ID attribute configuration.
- Modified `useAddonParameters` to utilize the new test ID attribute from configuration.