### PR TITLE
fix: fixes an issue where using getAbsolutePath would make the addon not work

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,12 +7,7 @@
 		"url": "git+https://github.com/igrlk/storybook-addon-test-codegen.git"
 	},
 	"packageManager": "pnpm@9.15.3",
-	"keywords": [
-		"storybook-addons",
-		"interactions",
-		"test",
-		"codegen"
-	],
+	"keywords": ["storybook-addons", "interactions", "test", "codegen"],
 	"main": "dist/index.cjs",
 	"module": "dist/index.js",
 	"types": "dist/index.d.ts",
@@ -34,12 +29,7 @@
 		"./manager": "./dist/manager.js",
 		"./package.json": "./package.json"
 	},
-	"files": [
-		"dist/**/*",
-		"README.md",
-		"*.js",
-		"*.d.ts"
-	],
+	"files": ["dist/**/*", "README.md", "*.js", "*.d.ts"],
 	"scripts": {
 		"build": "tsup",
 		"build:watch": "tsup --watch",
@@ -110,18 +100,10 @@
 		"access": "public"
 	},
 	"bundler": {
-		"exportEntries": [
-			"src/index.ts"
-		],
-		"managerEntries": [
-			"src/manager.tsx"
-		],
-		"previewEntries": [
-			"src/preview.ts"
-		],
-		"nodeEntries": [
-			"src/preset.ts"
-		]
+		"exportEntries": ["src/index.ts"],
+		"managerEntries": ["src/manager.tsx"],
+		"previewEntries": ["src/preview.ts"],
+		"nodeEntries": ["src/preset.ts"]
 	},
 	"storybook": {
 		"displayName": "Test Codegen",
@@ -139,8 +121,6 @@
 		"icon": "https://user-images.githubusercontent.com/321738/63501763-88dbf600-c4cc-11e9-96cd-94adadc2fd72.png"
 	},
 	"lint-staged": {
-		"*": [
-			"pnpm check"
-		]
+		"*": ["pnpm check"]
 	}
 }

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -3,12 +3,11 @@ import type { ProjectAnnotations, Renderer } from 'storybook/internal/types';
 import { IS_ASSERTING_KEY, IS_RECORDING_KEY } from './constants';
 import { withInteractionRecorder } from './decorators/with-interaction-recorder';
 
-const preview: ProjectAnnotations<Renderer> = {
-	decorators: [withInteractionRecorder],
-	initialGlobals: {
-		[IS_RECORDING_KEY]: false,
-		[IS_ASSERTING_KEY]: false,
-	},
-};
+export const decorators: ProjectAnnotations<Renderer>['decorators'] = [
+	withInteractionRecorder,
+];
 
-export default preview;
+export const initialGlobals: ProjectAnnotations<Renderer>['initialGlobals'] = {
+	[IS_RECORDING_KEY]: false,
+	[IS_ASSERTING_KEY]: false,
+};


### PR DESCRIPTION
This PR looks at fixing an issue where importing this addon using `getAbsolutePath` would break it when trying to start recordings in the browser. Applying a fix originating from [here](https://github.com/storybookjs/storybook/pull/24596).

Unsure how we could test this. Built it, ran tests and started up the storybook, verifying that everything still worked as it used too, but trying to use `getAbsolutePath` does not work since we are referring to a local js file in the `main.ts` file. Let me know if you want me to do anything else :)

closes #34 