### PR TITLE
e2e retries

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -7,7 +7,13 @@
 	},
 	"files": {
 		"ignoreUnknown": false,
-		"ignore": ["node_modules", "dist", "scripts", "storybook-static"]
+		"ignore": [
+			"node_modules",
+			"dist",
+			"scripts",
+			"storybook-static",
+			"playwright-report"
+		]
 	},
 	"formatter": {
 		"enabled": true,

--- a/e2e/addon.spec.ts
+++ b/e2e/addon.spec.ts
@@ -5,9 +5,20 @@ test('Submit multi-step form', async ({ page }) => {
 		'http://localhost:6006/?path=/story/stories-multistepform--default',
 	);
 	await page.getByRole('tab', { name: 'Interaction Recorder' }).click();
-	await page
-		.getByRole('button', { name: 'Start recording Stop recording' })
-		.click();
+
+	// Initial load doesn't allow to start the recording until the storybook is properly loaded
+	while (true) {
+		await page
+			.getByRole('button', { name: 'Start recording Stop recording' })
+			.click();
+
+		await new Promise((resolve) => setTimeout(resolve, 1000));
+
+		if (await page.getByText('Recording is in progress...').isVisible()) {
+			break;
+		}
+	}
+
 	await page
 		.locator('iframe[title="storybook-preview-iframe"]')
 		.contentFrame()

--- a/package.json
+++ b/package.json
@@ -7,12 +7,7 @@
 		"url": "git+https://github.com/igrlk/storybook-addon-test-codegen.git"
 	},
 	"packageManager": "pnpm@9.15.3",
-	"keywords": [
-		"storybook-addons",
-		"interactions",
-		"test",
-		"codegen"
-	],
+	"keywords": ["storybook-addons", "interactions", "test", "codegen"],
 	"main": "dist/index.cjs",
 	"module": "dist/index.js",
 	"types": "dist/index.d.ts",
@@ -34,12 +29,7 @@
 		"./manager": "./dist/manager.js",
 		"./package.json": "./package.json"
 	},
-	"files": [
-		"dist/**/*",
-		"README.md",
-		"*.js",
-		"*.d.ts"
-	],
+	"files": ["dist/**/*", "README.md", "*.js", "*.d.ts"],
 	"scripts": {
 		"build": "tsup",
 		"build:watch": "tsup --watch",
@@ -110,18 +100,10 @@
 		"access": "public"
 	},
 	"bundler": {
-		"exportEntries": [
-			"src/index.ts"
-		],
-		"managerEntries": [
-			"src/manager.tsx"
-		],
-		"previewEntries": [
-			"src/preview.ts"
-		],
-		"nodeEntries": [
-			"src/preset.ts"
-		]
+		"exportEntries": ["src/index.ts"],
+		"managerEntries": ["src/manager.tsx"],
+		"previewEntries": ["src/preview.ts"],
+		"nodeEntries": ["src/preset.ts"]
 	},
 	"storybook": {
 		"displayName": "Test Codegen",
@@ -139,8 +121,6 @@
 		"icon": "https://user-images.githubusercontent.com/321738/63501763-88dbf600-c4cc-11e9-96cd-94adadc2fd72.png"
 	},
 	"lint-staged": {
-		"*": [
-			"pnpm check"
-		]
+		"*": ["pnpm check"]
 	}
 }


### PR DESCRIPTION
E2Es started to fail on the step where we enable the recording. Storybook fails to immediately update the global variable responsible for recording state. 

This PR adds retries to that operation until "Recording is in progress" is visible