### PR TITLE
fix: build root package entry

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,3 @@
+import type { AddonTypes } from 'storybook/internal/csf';
+
+export interface AddonCodegenTypes extends AddonTypes {}

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -17,7 +17,12 @@ export default defineConfig(async (options) => {
 		await import('./package.json', { with: { type: 'json' } })
 	).default;
 	const {
-		bundler: { managerEntries = [], previewEntries = [], nodeEntries = [] },
+		bundler: {
+			exportEntries = [],
+			managerEntries = [],
+			previewEntries = [],
+			nodeEntries = [],
+		},
 	} = packageJson;
 
 	const commonConfig: Options = {
@@ -38,6 +43,18 @@ export default defineConfig(async (options) => {
 	};
 
 	const configs: Options[] = [];
+
+	// export entries back the package root and need to match main/module/types.
+	if (exportEntries.length) {
+		configs.push({
+			...commonConfig,
+			dts: true,
+			entry: exportEntries,
+			format: ['esm', 'cjs'],
+			platform: 'browser',
+			target: BROWSER_TARGET,
+		});
+	}
 
 	// manager entries are entries meant to be loaded into the manager UI
 	// they'll have manager-specific packages externalized and they won't be usable in node


### PR DESCRIPTION
## Summary

Build the package root entry advertised by `main`, `module`, `types`, and `exports["."]`.

## Root cause

`package.json` lists `bundler.exportEntries: ["src/index.ts"]`, but `tsup.config.ts` only reads manager, preview, and node entries. As a result, the published package contains `dist/manager.js`, `dist/preview.js`, and `dist/preset.js`, but not the advertised root files:

- `dist/index.cjs`
- `dist/index.js`
- `dist/index.d.ts`

Building the root entry also exposed that `src/index.ts` imports `./types`, so this adds the missing public addon type definition.

## Changes

- Include `exportEntries` in the tsup config.
- Emit the root entry as both ESM and CJS with declarations.
- Add `src/types.ts` for `AddonCodegenTypes`.

## Validation

- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm build`
- `pnpm test` (7 files, 170 tests passed)
- `npm pack --dry-run --json` confirms `dist/index.cjs`, `dist/index.js`, and `dist/index.d.ts` are packed
- `git diff --check HEAD~1 HEAD`

Note: `pnpm tsc` still fails on existing example story files that use React JSX without a runtime React import. That appears unrelated to this package entry fix; the package build and unit tests pass.