### PR TITLE
fix: Only reset recording globals on story change when recording is active

### DIFF
--- a/src/InteractionRecorder.tsx
+++ b/src/InteractionRecorder.tsx
@@ -71,7 +71,12 @@ export const InteractionRecorder = () => {
 	// biome-ignore lint/correctness/useExhaustiveDependencies: reset events & recording when story changes
 	useEffect(() => {
 		resetInteractions();
-		turnOffRecording();
+		// Only emit a globals update when there is something to turn off. Unconditional
+		// setGlobals on every story change forces a story re-render that can abort the
+		// incoming story's play function mid-handoff, showing a false "Bail" status.
+		if (isRecording || isAsserting) {
+			turnOffRecording();
+		}
 	}, [storyData?.id]);
 
 	const hasTypescript = ['.ts', '.tsx'].some((ext) =>


### PR DESCRIPTION
Fixes #52

## Problem

The InteractionRecorder panel resets its recording globals on every story change, even when recording is off:

```js
useEffect(() => {
  resetInteractions();
  turnOffRecording(); // emits setGlobals twice, even when both are already false
}, [storyData?.id]);
```

Storybook does not dedupe unchanged globals, so each broadcast forces a story re-render. On SPA story navigation that re-render lands mid-handoff and aborts the outgoing story's render, and the Interactions panel shows a false "Bail" / "Interactions aborted due to file changes" status on the newly opened story, even though its play function ran and passed. Vite-based frameworks reproduce this nearly 100% of the time because story modules load fast enough for the render to be in flight when the globals updates arrive (details and a channel-event trace in #52).

## Fix

Only call `turnOffRecording()` when recording or assertion mode is actually on, so the common case (not recording) emits no globals update at all:

```js
useEffect(() => {
  resetInteractions();
  if (isRecording || isAsserting) {
    turnOffRecording();
  }
}, [storyData?.id]);
```

Recording behavior is unchanged: navigating away while recording still turns recording off.

## Verification

- `pnpm test`: 170/170 pass
- `biome check`: clean
- `pnpm build`: success
- Verified in a large Storybook (2,500+ stories, `@storybook/nextjs-vite` 10.4.6): with this change applied, SPA navigation across stories with play functions shows Pass consistently (previously Bail on every navigation). We are currently shipping this exact change as a yarn patch and will drop the patch once it lands here.
