### PR TITLE
fix: add bugs and homepage metadata to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
 		"type": "git",
 		"url": "git+https://github.com/igrlk/storybook-addon-test-codegen.git"
 	},
+	"bugs": {
+		"url": "https://github.com/igrlk/storybook-addon-test-codegen/issues"
+	},
+	"homepage": "https://github.com/igrlk/storybook-addon-test-codegen#readme",
 	"packageManager": "pnpm@9.15.3",
 	"keywords": [
 		"storybook-addons",


### PR DESCRIPTION
Adds the standard npm `bugs` and `homepage` fields to `package.json` so npm and tooling surface the correct links (issue tracker + project page). Powers `npm bugs`, the "report issue" link, and the homepage link on the npm package page.

```json
"bugs": {
  "url": "https://github.com/igrlk/storybook-addon-test-codegen/issues"
},
"homepage": "https://github.com/igrlk/storybook-addon-test-codegen#readme",
```

Supersedes #48 and #51, which added the same idea but rewrote the entire file (tabs → spaces) and, in #48's case, used malformed `git+` URLs for `bugs`/`homepage`. This is a minimal, correctly-formatted 4-line change with no reformatting churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)